### PR TITLE
Ensure search states yield immutable snapshots

### DIFF
--- a/src/algorithms/astar.py
+++ b/src/algorithms/astar.py
@@ -69,7 +69,8 @@ def astar_search_generator(labyrinth, start, goal, time_limit):
         visited.add(current_node)
 
         # Pošaljemo trenutnu sliku pretrage
-        yield ("searching", visited, current_node, current_path)
+        # Kopiramo strukture prije slanja kako bismo očuvali trenutni snapshot
+        yield ("searching", visited.copy(), current_node, current_path.copy())
 
         # Ako smo na cilju
         if current_node == goal:

--- a/src/algorithms/bfs.py
+++ b/src/algorithms/bfs.py
@@ -44,7 +44,9 @@ def bfs_search_generator(labyrinth, start, goal, time_limit=None):
         # Pokažemo trenutno stanje BFS-a
         # 'path_so_far' je put do 'current' (privremeno), za vizualizaciju
         path_so_far = reconstruct_path(parent_map, current)
-        yield ("searching", visited, current, path_so_far)
+        # Emitiramo kopije struktura da bi vizualizacija koristila nepromjenjive
+        # "snapshot" vrijednosti umjesto objektâ koji će se kasnije mijenjati.
+        yield ("searching", visited.copy(), current, path_so_far.copy())
 
         if current == goal:
             # Pronađen cilj: rekonstruišemo finalni path

--- a/src/algorithms/dfs.py
+++ b/src/algorithms/dfs.py
@@ -41,8 +41,9 @@ def dfs_search_generator(labyrinth, start, goal, time_limit=None):
 
         current_node, current_path = stack.pop()
 
-        # Yield stanje pretrage: skup svih posjećenih čvorova do sada, trenutni čvor, putanja do njega
-        yield ("searching", visited_nodes, current_node, current_path)
+        # Yield stanje pretrage: koristimo kopije struktura kako bi prikaz
+        # dobio nepromjenjive "snapshot" vrijednosti.
+        yield ("searching", visited_nodes.copy(), current_node, current_path.copy())
 
         if current_node == goal:
             duration = time.time() - start_time # Ponovno dohvati vrijeme za točnost


### PR DESCRIPTION
## Summary
- maintain copies of visited and path data when yielding BFS, DFS, and A* search states
- keep visualization input immutable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f4159af8c832f81465e59852b202a